### PR TITLE
Uppercase method name

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -19,7 +19,7 @@ export class Request {
 
   get fetchOptions () {
     return {
-      method: this.method,
+      method: this.method.toUpperCase(),
       headers: this.headers,
       body: this.body,
       signal: this.signal,


### PR DESCRIPTION
Using `new Request("post", url)` will send lowercase `post` as the method which causes Puma (and others) to raise a 400 Bad Request. 

This patch uppercases the method name, just like [Rails.ajax did](https://github.com/rails/rails/blob/main/actionview/app/assets/javascripts/rails-ujs/utils/ajax.coffee#L33).