### PR TITLE
Automatically inserts Turbo Stream responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ async myMethod () {
 }
 ```
 
+#### Turbo Streams
+
+Request.JS will automatically process Turbo Stream responses. Ensure that your Javascript sets the `window.Turbo` global variable:
+
+```javascript
+import { Turbo } from "@hotwired/turbo-rails"
+window.Turbo = Turbo
+```
+
 # License
 
 Rails Request.JS is released under the [MIT License](LICENSE).

--- a/src/request.js
+++ b/src/request.js
@@ -13,6 +13,7 @@ export class Request {
     if (response.unauthenticated && response.authenticationURL) {
       return Promise.reject(window.location.href = response.authenticationURL)
     } else {
+      if (response.ok && response.isTurboStream) { response.renderTurboStream() }
       return response
     }
   }

--- a/src/response.js
+++ b/src/response.js
@@ -47,4 +47,20 @@ export class Response {
   get text () {
     return this.response.text()
   }
+
+  get isTurboStream () {
+    return this.contentType.match(/^text\/vnd\.turbo-stream\.html/)
+  }
+
+  async renderTurboStream () {
+    if (this.isTurboStream) {
+      if (window.Turbo) {
+        Turbo.renderStreamMessage(await this.text)
+      } else {
+        console.warn('You must set `window.Turbo = Turbo` to automatically process Turbo Stream events with request.js')
+      }
+    } else {
+      return Promise.reject(new Error(`Expected a Turbo Stream response but got "${this.contentType}" instead`))
+    }
+  }
 }


### PR DESCRIPTION
The user may not realize this how to execute Turbo Stream actions in the response, so it is nice if we can take care of it for them. By automatically inserting the Turbo Stream responses into the body, we can apply those operations automatically for the user. 

I couldn't think of any situations where you might want to disable this, but we could add an option to disable it if needed.

Thoughts on this or how it can be improved?

cc @dhh 