### PR TITLE
Allow additional/custom headers in request

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -29,12 +29,15 @@ export class Request {
   }
 
   get headers () {
-    return compact({
-      'X-Requested-With': 'XMLHttpRequest',
-      'X-CSRF-Token': this.csrfToken,
-      'Content-Type': this.contentType,
-      Accept: this.accept
-    })
+    return compact(
+      Object.assign({
+        'X-Requested-With': 'XMLHttpRequest',
+        'X-CSRF-Token': this.csrfToken,
+        'Content-Type': this.contentType,
+        Accept: this.accept
+      },
+      this.additionalHeaders)
+    )
   }
 
   get csrfToken () {
@@ -76,6 +79,10 @@ export class Request {
 
   get signal () {
     return this.options.signal
+  }
+
+  get additionalHeaders () {
+    return this.options.headers || {}
   }
 }
 


### PR DESCRIPTION
This change allows for the user to specify additional headers in the request object.

```
const request = new Request('post', 'localhost:3000/my_endpoint', { 
  body: { name: 'Request.JS' }, 
  headers: { 'X-Custom-Header': '...' } 
})
```

Anything in the `headers` option is merged into the preset headers. Last one in wins, so this should also allow for overriding defaults if desired.