### PR TITLE
Add prefix `Fetch` to the `Request` and `Response` classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn add @rails/request.js
 
 # How to use
 
-Just import the `Request` class from the package and instantiate it passing the request `method`, `url`, `options`,  then call `await request.perform()` and do what do you need with the response.
+Just import the `FetchRequest` class from the package and instantiate it passing the request `method`, `url`, `options`,  then call `await request.perform()` and do what do you need with the response.
 
 Example:
 
@@ -25,7 +25,7 @@ import { Request } from '@rails/request.js'
 ....
 
 async myMethod () {
-  const request = new Request('post', 'localhost:3000/my_endpoint', { body: { name: 'Request.JS' }})
+  const request = new FetchRequest('post', 'localhost:3000/my_endpoint', { body: { name: 'Request.JS' }})
   const response = await request.perform()
   if (response.ok) {
     const body = await response.text

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -1,7 +1,7 @@
-import { Response } from './response'
+import { FetchResponse } from './fetch_response'
 import { getCookie } from './lib/cookie'
 
-export class Request {
+export class FetchRequest {
   constructor (method, url, options = {}) {
     this.method = method
     this.url = url
@@ -9,7 +9,7 @@ export class Request {
   }
 
   async perform () {
-    const response = new Response(await window.fetch(this.url, this.fetchOptions))
+    const response = new FetchResponse(await window.fetch(this.url, this.fetchOptions))
     if (response.unauthenticated && response.authenticationURL) {
       return Promise.reject(window.location.href = response.authenticationURL)
     } else {

--- a/src/fetch_response.js
+++ b/src/fetch_response.js
@@ -1,4 +1,4 @@
-export class Response {
+export class FetchResponse {
   constructor (response) {
     this.response = response
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { Request } from './request'
-import { Response } from './response'
+import { FetchRequest } from './fetch_request'
+import { FetchResponse } from './fetch_response'
 
-export { Request, Response }
+export { FetchRequest, FetchResponse }


### PR DESCRIPTION
As pointed in https://github.com/rails/request.js/issues/3 the actual Request/Response classes clashes with the built-in classes.

Turbo has similar classes too and they are named `FetchRequest`/`FetchResponse`, to me I think that we can use the same names since Turbo doesn't export those classes.

Closes #3 