### PR TITLE
adds 5 shorthand functions for request verbs get, post, put, patch, destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ async myMethod () {
 }
 ```
 
+#### Shorthand methods
+
+Alternatively, you can use a shorthand version for the main HTTP verbs, `get`, `post`, `put`, `patch` or `destroy`.
+
+Example:
+
+```js
+import { get, post, put, patch, destroy } from '@rails/request.js'
+
+...
+
+async myMethod () {
+  const response = await post('localhost:3000/my_endpoint', { body: { name: 'Request.JS' }})
+  if (response.ok) {
+    ...
+  }
+}
+```
+
+
 #### Turbo Streams
 
 Request.JS will automatically process Turbo Stream responses. Ensure that your Javascript sets the `window.Turbo` global variable:

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { Request } from './request'
 import { Response } from './response'
+import {get, post, put, patch, destroy} from './verbs'
 
-export { Request, Response }
+export { Request, Response, get, post, put, patch, destroy}

--- a/src/verbs.js
+++ b/src/verbs.js
@@ -1,0 +1,28 @@
+import { Request } from "./request";
+
+async function get (url, options) {
+  const response = new Request("get", url, options)
+  return response.perform()
+}
+
+async function post(url, options) {
+  const response = new Request("post", url, options);
+  return response.perform();
+}
+
+async function put(url, options) {
+  const response = new Request("put", url, options);
+  return response.perform();
+}
+
+async function patch(url, options) {
+  const response = new Request("patch", url, options);
+  return response.perform();
+}
+
+async function destroy(url, options) {
+  const response = new Request("delete", url, options);
+  return response.perform();
+}
+
+export { get, post, put, patch, destroy };

--- a/src/verbs.js
+++ b/src/verbs.js
@@ -1,28 +1,28 @@
-import { Request } from "./request";
+import { Request } from './request'
 
 async function get (url, options) {
-  const response = new Request("get", url, options)
+  const response = new Request('get', url, options)
   return response.perform()
 }
 
-async function post(url, options) {
-  const response = new Request("post", url, options);
-  return response.perform();
+async function post (url, options) {
+  const response = new Request('post', url, options)
+  return response.perform()
 }
 
-async function put(url, options) {
-  const response = new Request("put", url, options);
-  return response.perform();
+async function put (url, options) {
+  const response = new Request('put', url, options)
+  return response.perform()
 }
 
-async function patch(url, options) {
-  const response = new Request("patch", url, options);
-  return response.perform();
+async function patch (url, options) {
+  const response = new Request('patch', url, options)
+  return response.perform()
 }
 
-async function destroy(url, options) {
-  const response = new Request("delete", url, options);
-  return response.perform();
+async function destroy (url, options) {
+  const response = new Request('delete', url, options)
+  return response.perform()
 }
 
-export { get, post, put, patch, destroy };
+export { get, post, put, patch, destroy }

--- a/src/verbs.js
+++ b/src/verbs.js
@@ -1,27 +1,27 @@
-import { Request } from './request'
+import { FetchRequest } from './fetchRequest'
 
 async function get (url, options) {
-  const response = new Request('get', url, options)
+  const response = new FetchRequest('get', url, options)
   return response.perform()
 }
 
 async function post (url, options) {
-  const response = new Request('post', url, options)
+  const response = new FetchRequest('post', url, options)
   return response.perform()
 }
 
 async function put (url, options) {
-  const response = new Request('put', url, options)
+  const response = new FetchRequest('put', url, options)
   return response.perform()
 }
 
 async function patch (url, options) {
-  const response = new Request('patch', url, options)
+  const response = new FetchRequest('patch', url, options)
   return response.perform()
 }
 
 async function destroy (url, options) {
-  const response = new Request('delete', url, options)
+  const response = new FetchRequest('delete', url, options)
   return response.perform()
 }
 


### PR DESCRIPTION
close #9 

This PR adds shorthand functions to directly call one specific HTTP request verb.

5 new functions are available : get, post, put, patch, destroy

### Example 
```js
import {get, post, put, patch, destroy} from '@rails/request.js'

async myMethod () {
  const response = await post('localhost:3000/my_endpoint', { body: { name: 'Request.JS' }}))
  if (response.ok) {
    const body = await response.text
    ...
  }
}
```

### DELETE -> `destroy`

`delete` is a javascript reserved word so for this shorthand function I used `destroy`
