### PR TITLE
Add request interceptor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,28 @@ import { Turbo } from "@hotwired/turbo-rails"
 window.Turbo = Turbo
 ```
 
+#### Request Interceptor
+
+To authenticate fetch requests (eg. with Bearer token) you can use request interceptor. It allows pausing request invocation for fetching token and then adding it to headers:
+
+```javascript
+import { RequestInterceptor } from '@rails/request.js'
+// ...
+
+// Set interceptor
+RequestInterceptor.register(async (request) => {
+  const token = await getSessionToken(window.app)
+  request.addHeader('Authorization', `Bearer ${token}`)
+})
+
+// Reset interceptor
+RequestInterceptor.reset()
+```
+
 # Known Issues
 
 `FetchRequest` sets a `"X-Requested-With": "XmlHttpRequest"` header. If you have not upgraded to Turbo and still use `Turbolinks` in your Gemfile, this means
-you will not be able to check if the request was redirected. 
+you will not be able to check if the request was redirected.
 
 ```js
   const request = new FetchRequest('post', 'localhost:3000/my_endpoint', { body: { name: 'Request.JS' }})

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { FetchRequest } from './fetch_request'
 import { FetchResponse } from './fetch_response'
+import { RequestInterceptor } from './request_interceptor'
 
-export { FetchRequest, FetchResponse }
+export { FetchRequest, FetchResponse, RequestInterceptor }

--- a/src/request_interceptor.js
+++ b/src/request_interceptor.js
@@ -1,0 +1,13 @@
+export class RequestInterceptor {
+  static register (interceptor) {
+    this.interceptor = interceptor
+  }
+
+  static get () {
+    return this.interceptor
+  }
+
+  static reset () {
+    this.interceptor = undefined
+  }
+}


### PR DESCRIPTION
## Problem

Modern embedded Shopify apps are built with JWT session tokens that need to be passed to every server request. The token needs to be fetched right before the request. Without token, all Ajax requests to the server will fail.

## Solution

This PR introduces request interceptor support. It allows inserting the async function between every fetch request. Inside this function, you can do some preparation for requests and add custom headers. I already proposed the same API for Turbo (https://github.com/hotwired/turbo/pull/177).

## Example usage

```javascript
import { RequestInterceptor } from '@rails/request.js'
// ...

// Set interceptor
RequestInterceptor.register(async (request) => {
  const token = await getSessionToken(window.app)
  request.addHeader('Authorization', `Bearer ${token}`)
})

// Reset interceptor
RequestInterceptor.reset()
```