### PR TITLE
Fix renderTurboStream return

### DIFF
--- a/src/fetch_response.js
+++ b/src/fetch_response.js
@@ -60,8 +60,8 @@ export class FetchResponse {
       } else {
         console.warn('You must set `window.Turbo = Turbo` to automatically process Turbo Stream events with request.js')
       }
+    } else {
+      return Promise.reject(new Error(`Expected a Turbo Stream response but got "${this.contentType}" instead`))
     }
-
-    return Promise.reject(new Error(`Expected a Turbo Stream response but got "${this.contentType}" instead`))
   }
 }


### PR DESCRIPTION
#15 incorrectly refactored the `renderTurboStream` method so that it always returns a rejected Promise.

This fixes that by returning properly when the contentType is correct.