### PR TITLE
Cache text and json after reading

### DIFF
--- a/src/fetch_response.js
+++ b/src/fetch_response.js
@@ -31,7 +31,7 @@ export class FetchResponse {
 
   get html () {
     if (this.contentType.match(/^(application|text)\/(html|xhtml\+xml)$/)) {
-      return this.response.text()
+      return this.text
     }
 
     return Promise.reject(new Error(`Expected an HTML response but got "${this.contentType}" instead`))
@@ -39,14 +39,14 @@ export class FetchResponse {
 
   get json () {
     if (this.contentType.match(/^application\/json/)) {
-      return this.response.json()
+      return this.responseJson || (this.responseJson = this.response.json())
     }
 
     return Promise.reject(new Error(`Expected a JSON response but got "${this.contentType}" instead`))
   }
 
   get text () {
-    return this.response.text()
+    return this.responseText || (this.responseText = this.response.text())
   }
 
   get isTurboStream () {


### PR DESCRIPTION
This saves the `text` and `json` values after reading. Fetch responses don't allow you to read these twice, so it's best if we memoize the results to prevent users from running into this.

```javascript
const request = new FetchRequest("post", url)
const response = await request.perform()
await response.text
await response.text
// => Failed to execute 'text' on 'Response': body stream already read
```

Most importantly, we need memoization so you can still read the response text after the Turbo Stream messages are read and rendered.
```
const request = new FetchRequest("post", url, { responseKind: "turbo-stream" })
const response = await request.perform()
await response.text
// => Failed to execute 'text' on 'Response': body stream already read
```

Fixes #19