### PR TITLE
Expose response.redirected to FetchResponse

### DIFF
--- a/src/fetch_response.js
+++ b/src/fetch_response.js
@@ -7,6 +7,10 @@ export class FetchResponse {
     return this.response.status
   }
 
+  get redirected () {
+    return this.response.redirected
+  }
+
   get ok () {
     return this.response.ok
   }


### PR DESCRIPTION
I could be completely off-base, but in the known limitations section in the README, I don't think this code actually would work...

```javascript
  const request = new FetchRequest('post', 'localhost:3000/my_endpoint', { body: { name: 'Request.JS' }})
  const response = await request.perform()
  response.redirected // => will always be false.
```

I am pretty sure `response` in this case is a `FetchResponse` and not a `Response`, so `redirected` wouldn't be defined.

I exposed `redirect` from the internal `respose` object in `FetchResponse` to at least make the code in the README correct.
