### PR TITLE
Allow redirect value to be configurable

### DIFF
--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -44,7 +44,7 @@ export class FetchRequest {
       body: this.formattedBody,
       signal: this.signal,
       credentials: 'same-origin',
-      redirect: 'follow'
+      redirect: this.redirect
     }
   }
 
@@ -99,6 +99,10 @@ export class FetchRequest {
 
   get signal () {
     return this.options.signal
+  }
+
+  get redirect () {
+    return this.options.redirect || 'follow'
   }
 
   get additionalHeaders () {


### PR DESCRIPTION
While rare, there may be a case when the developer wishes to manually handle a redirected response.

The fetch api defines three values for the `redirect` option, "follow" (what request.js currently sets), "manual", and "error".

This change allows `redirect` to be passed as one of the `options` and will set the `redirect` option on the reqeust object. If not set, it will default to "follow" which is what the library currently does.