### PR TITLE
Make `query` to accept a FormData

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Adds additional headers to the request.  `X-CSRF-Token` and `Content-Type` are a
 
 Appends query parameters to the URL. Query params in the URL are preserved and merged with the query options.
 
+Accepts `Object`, `FormData` or `URLSearchParams`.
+
 ##### responseKind
 
 Specifies which response format will be accepted. Default is `html`.

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -29,3 +29,22 @@ export function metaContent (name) {
   const element = document.head.querySelector(`meta[name="${name}"]`)
   return element && element.content
 }
+
+export function stringEntriesFromFormData (formData) {
+  return [...formData].reduce((entries, [name, value]) => {
+    return entries.concat(typeof value === 'string' ? [[name, value]] : [])
+  }, [])
+}
+
+export function mergeEntries (searchParams, entries) {
+  for (const [name, value] of entries) {
+    if (value instanceof window.File) continue
+
+    if (searchParams.has(name)) {
+      searchParams.delete(name)
+      searchParams.set(name, value)
+    } else {
+      searchParams.append(name, value)
+    }
+  }
+}


### PR DESCRIPTION
Allows a user to send a FormData as query params. Request.js will parse the FormData to query params and append them to the URL in the same way it's done when an object is provided.

Example
```js
import { get } from '@rails/request.js'
...
async myMethod () {
  const fakeForm = new FormData()
  fakeForm.append('name', 'Marcelo')
  get('/endpoint', { query: fakeForm }) // translates to /endpoint?name=Marcelo
}
```

Ref: https://github.com/rails/request.js/pull/28