### PR TITLE
Check if response status is unprocessableEntity

### DIFF
--- a/src/fetch_response.js
+++ b/src/fetch_response.js
@@ -18,6 +18,10 @@ export class FetchResponse {
   get unauthenticated () {
     return this.statusCode === 401
   }
+  
+  get unprocessableEntity () {
+    return this.statusCode === 422
+  }
 
   get authenticationURL () {
     return this.response.headers.get('WWW-Authenticate')

--- a/src/fetch_response.js
+++ b/src/fetch_response.js
@@ -18,7 +18,7 @@ export class FetchResponse {
   get unauthenticated () {
     return this.statusCode === 401
   }
-  
+
   get unprocessableEntity () {
     return this.statusCode === 422
   }


### PR DESCRIPTION
This PR adds a convenient helper to check for `unprocessableEntity` response status.

I bet we don't want to add a helper for each status code but this is motivated by the fact that Rails now returns `422` status code by default for form submission with error https://github.com/rails/rails/pull/41026

So, we can legitimately expect doing this kind of check more often.