### PR TITLE
Await turbo stream insertion in DOM

### DIFF
--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -26,7 +26,7 @@ export class FetchRequest {
     }
 
     if (response.ok && response.isTurboStream) {
-      response.renderTurboStream()
+      await response.renderTurboStream()
     }
 
     return response

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -93,6 +93,14 @@ export class FetchRequest {
     return this.options.body
   }
 
+  get query () {
+    if (this.options.query) {
+      return `?${new URLSearchParams(this.options.query)}`
+    } else {
+      return ''
+    }
+  }
+
   get responseKind () {
     return this.options.responseKind || 'html'
   }

--- a/src/fetch_response.js
+++ b/src/fetch_response.js
@@ -64,7 +64,7 @@ export class FetchResponse {
   async renderTurboStream () {
     if (this.isTurboStream) {
       if (window.Turbo) {
-        window.Turbo.renderStreamMessage(await this.text)
+        await window.Turbo.renderStreamMessage(await this.text)
       } else {
         console.warn('You must set `window.Turbo = Turbo` to automatically process Turbo Stream events with request.js')
       }


### PR DESCRIPTION
Turbo Streams are inserted into the DOM async currently. Being able to wait until these elements are inserted allows for the user to apply animations and take other actions after the insert is complete.

The wait won't break any existing usage, it would only introduce a small wait while the elements are inserted.

This should fix #35 