### PR TITLE
Support URL objects

### DIFF
--- a/__tests__/fetch_request.js
+++ b/__tests__/fetch_request.js
@@ -66,6 +66,11 @@ test('treat method name case-insensitive', async () => {
   }
 })
 
+test('casts URL to String', async () => {
+  const testRequest = new FetchRequest("GET", new URL("http://localhost"))
+  expect(typeof testRequest.originalUrl).toBe("string")
+})
+
 describe('header handling', () => {
   const defaultHeaders = {
     'X-Requested-With': 'XMLHttpRequest',

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -6,7 +6,7 @@ export class FetchRequest {
   constructor (method, url, options = {}) {
     this.method = method
     this.options = options
-    this.originalUrl = url
+    this.originalUrl = url.toString()
   }
 
   async perform () {

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -93,6 +93,14 @@ export class FetchRequest {
     return this.options.body
   }
 
+  get query () {
+    if (this.options.query) {
+      return `?${new URLSearchParams(this.options.query)}`
+    } else {
+      return ''
+    }
+  }
+
   get responseKind () {
     return this.options.responseKind || 'html'
   }


### PR DESCRIPTION
Fixes #38 

Allows you to pass in URL or other objects as the `url` argument. We simply cast them to a String to make sure we have a string to work with.