### PR TITLE
Allow for 'application/vnd.api+json' response.

### DIFF
--- a/__tests__/fetch_request.js
+++ b/__tests__/fetch_request.js
@@ -91,7 +91,7 @@ describe('header handling', () => {
     test('json', async () => {
       const jsonRequest = new FetchRequest("get", "localhost", { responseKind: 'json' })
       expect(jsonRequest.fetchOptions.headers)
-        .toStrictEqual({...defaultHeaders, 'Accept' : 'application/json'})
+        .toStrictEqual({...defaultHeaders, 'Accept' : 'application/json, application/vnd.api+json'})
     })
     test('turbo-stream', async () => {
       const turboRequest = new FetchRequest("get", "localhost", { responseKind: 'turbo-stream' })

--- a/__tests__/fetch_response.js
+++ b/__tests__/fetch_response.js
@@ -52,9 +52,24 @@ describe('body accessors', () => {
       expect({ json: 'body' }).toStrictEqual(await testResponse.json)
     })
     test('rejects on invalid content-type', async () => {
-      const mockResponse = new Response("<h1>hi</h1>", { status: 200, headers: new Headers({'Content-Type': 'text/plain'}) })
+      const mockResponse = new Response("<h1>hi</h1>", { status: 200, headers: new Headers({'Content-Type': 'text/json'}) })
       const testResponse = new FetchResponse(mockResponse)
     
+      expect(testResponse.json).rejects.toBeInstanceOf(Error)
+    })
+  })
+  describe('application/vnd.api+json', () => {
+    test('works multiple times', async () => {
+      const mockResponse = new Response(JSON.stringify({ json: 'body' }), { status: 200, headers: new Headers({'Content-Type': 'application/vnd.api+json'}) })
+      const testResponse = new FetchResponse(mockResponse)
+
+      expect({ json: 'body' }).toStrictEqual(await testResponse.json)
+      expect({ json: 'body' }).toStrictEqual(await testResponse.json)
+    })
+    test('rejects on invalid content-type', async () => {
+      const mockResponse = new Response("<h1>hi</h1>", { status: 200, headers: new Headers({'Content-Type': 'application/plain'}) })
+      const testResponse = new FetchResponse(mockResponse)
+
       expect(testResponse.json).rejects.toBeInstanceOf(Error)
     })
   })

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -84,7 +84,7 @@ export class FetchRequest {
       case 'turbo-stream':
         return 'text/vnd.turbo-stream.html, text/html, application/xhtml+xml'
       case 'json':
-        return 'application/json'
+        return 'application/json, application/vnd.api+json'
       default:
         return '*/*'
     }

--- a/src/fetch_response.js
+++ b/src/fetch_response.js
@@ -46,7 +46,7 @@ export class FetchResponse {
   }
 
   get json () {
-    if (this.contentType.match(/^application\/json/)) {
+    if (this.contentType.match(/^application\/.*json$/)) {
       return this.responseJson || (this.responseJson = this.response.json())
     }
 


### PR DESCRIPTION
This PR adds the ability to accept `application/vnd.api+json` response content types, and changes the regular expression to look for content types beginning with `application` and ending in `json`.

This is useful for anyone who is using a [JSON::API](https://jsonapi.org) specific API.