### PR TITLE
Do not send CSRF token for external requests

### DIFF
--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -38,6 +38,18 @@ export class FetchRequest {
     this.options.headers = headers
   }
 
+  sameHostname () {
+    if (!this.originalUrl.startsWith('http:')) {
+      return true
+    }
+
+    try {
+      return new URL(this.originalUrl).hostname === window.location.hostname
+    } catch (_) {
+      return true
+    }
+  }
+
   get fetchOptions () {
     return {
       method: this.method.toUpperCase(),
@@ -50,14 +62,18 @@ export class FetchRequest {
   }
 
   get headers () {
+    const baseHeaders = {
+      'X-Requested-With': 'XMLHttpRequest',
+      'Content-Type': this.contentType,
+      Accept: this.accept
+    }
+
+    if (this.sameHostname()) {
+      baseHeaders['X-CSRF-Token'] = this.csrfToken
+    }
+
     return compact(
-      Object.assign({
-        'X-Requested-With': 'XMLHttpRequest',
-        'X-CSRF-Token': this.csrfToken,
-        'Content-Type': this.contentType,
-        Accept: this.accept
-      },
-      this.additionalHeaders)
+      Object.assign(baseHeaders, this.additionalHeaders)
     )
   }
 


### PR DESCRIPTION
This library could be used for any AJAX request, however it was reported that some 3rd party endpoints reject the request if the CSRF token is included in the headers.

This change excludes the CSRF token from the headers by comparing the request URL and `window.location.hostname`.

- If the URL is a relative path (ie doesn't begin with "http:"), include the token.
- If the URL is not parseable with `new URL()`, then we'll continue on and include the token.
- If the hostname of the URL and from `window.location` are equal, include the token.
- If the hostname of the URL and from `window.location` are different, do not include the token.

I beleive this covers and maintains the existing expectations of the library so existing applications shouldn't be caught off gaurd as we are including the token more often than not.

Closes #45 