### PR TITLE
Allow turbo streams for unprocessable entity responses

### DIFF
--- a/__tests__/fetch_request.js
+++ b/__tests__/fetch_request.js
@@ -44,7 +44,7 @@ describe('perform', () => {
     })
   })
 
-  test('turbo stream request automatically calls renderTurboStream', async () => {
+  test('turbo stream request automatically calls renderTurboStream when status is ok', async () => {
     const mockResponse = new Response('', { status: 200, headers: { 'Content-Type': 'text/vnd.turbo-stream.html' }})
     window.fetch = jest.fn().mockResolvedValue(mockResponse)
     jest.spyOn(FetchResponse.prototype, "ok", "get").mockReturnValue(true)
@@ -55,6 +55,21 @@ describe('perform', () => {
     await testRequest.perform()
 
     expect(renderSpy).toHaveBeenCalledTimes(1)
+    jest.clearAllMocks();
+  })
+
+  test('turbo stream request automatically calls renderTurboStream when status is unprocessable entity', async () => {
+    const mockResponse = new Response('', { status: 422, headers: { 'Content-Type': 'text/vnd.turbo-stream.html' }})
+    window.fetch = jest.fn().mockResolvedValue(mockResponse)
+    jest.spyOn(FetchResponse.prototype, "ok", "get").mockReturnValue(true)
+    jest.spyOn(FetchResponse.prototype, "isTurboStream", "get").mockReturnValue(true)
+    const renderSpy = jest.spyOn(FetchResponse.prototype, "renderTurboStream").mockImplementation()
+
+    const testRequest = new FetchRequest("get", "localhost")
+    await testRequest.perform()
+
+    expect(renderSpy).toHaveBeenCalledTimes(1)
+    jest.clearAllMocks();
   })
 })
 

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -25,7 +25,9 @@ export class FetchRequest {
       return Promise.reject(window.location.href = response.authenticationURL)
     }
 
-    if (response.ok && response.isTurboStream) {
+    const responseStatusIsTurboStreamable = response.ok || response.unprocessableEntity
+
+    if (responseStatusIsTurboStreamable && response.isTurboStream) {
       await response.renderTurboStream()
     }
 


### PR DESCRIPTION
Since Rails can respond with 422 when form validation fails for example, allow request.js to perform and render turbo stream messages for both 200 and 422 response codes.