### PR TITLE
Allow credentials option to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ When provided this value will be sent in the `Content-Type` header. When not pro
 
 Adds additional headers to the request.  `X-CSRF-Token` and `Content-Type` are automatically included.
 
+##### credentials
+
+Specifies the `credentials` option. Default is `same-origin`.
+
 ##### query
 
 Appends query parameters to the URL. Query params in the URL are preserved and merged with the query options.

--- a/__tests__/fetch_request.js
+++ b/__tests__/fetch_request.js
@@ -198,14 +198,13 @@ describe('header handling', () => {
     expect(request.fetchOptions.signal).toBe("signal")
   })
 
-  test('has fixed credentials setting which cannot be changed', () => {
+  test('has credentials setting which can be changed', () => {
     let request
     request = new FetchRequest("get", "localhost")
     expect(request.fetchOptions.credentials).toBe('same-origin')
 
-    // has no effect
-    request = new FetchRequest("get", "localhost", { credentials: "omit"})
-    expect(request.fetchOptions.credentials).toBe('same-origin')
+    request = new FetchRequest("get", "localhost", { credentials: "include"})
+    expect(request.fetchOptions.credentials).toBe('include')
   })
 
   describe('csrf token inclusion', () => {

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -58,7 +58,7 @@ export class FetchRequest {
       headers: this.headers,
       body: this.formattedBody,
       signal: this.signal,
-      credentials: 'same-origin',
+      credentials: this.credentials,
       redirect: this.redirect
     }
   }
@@ -145,6 +145,10 @@ export class FetchRequest {
 
   get redirect () {
     return this.options.redirect || 'follow'
+  }
+
+  get credentials () {
+    return this.options.credentials || 'same-origin'
   }
 
   get additionalHeaders () {


### PR DESCRIPTION
Closes #55 

Right now, the credentials option for the request object is locked to `same-origin`. `omit` and `include` are two additional valid options.

This allows the user to set the value through the options object. If not set, we still default to `same-origin`.