### PR TITLE
Use window.Turbo.fetch if available for turbo-stream requests

### DIFF
--- a/__tests__/fetch_request.js
+++ b/__tests__/fetch_request.js
@@ -281,3 +281,34 @@ describe('query params are parsed', () => {
     expect(emptyQueryRequest.url).toBe("localhost/test")
   })
 })
+
+
+describe('turbostream', () => {
+  test('turbo fetch is called for turbo-stream responseKind', async() => {
+    const mockResponse = new Response("success!", { status: 200 })
+
+    window.fetch = jest.fn().mockResolvedValue(mockResponse)
+    window.Turbo = { fetch: jest.fn().mockResolvedValue(mockResponse) }
+
+    const testRequest = new FetchRequest("get", "localhost", { responseKind: 'turbo-stream' })
+    const testResponse = await testRequest.perform()
+
+    expect(window.Turbo.fetch).toHaveBeenCalledTimes(1)
+    expect(window.fetch).toHaveBeenCalledTimes(0)
+    expect(testResponse).toStrictEqual(new FetchResponse(mockResponse))
+  })
+
+  test('turbo fetch is called for other responseKind', async() => {
+    const mockResponse = new Response("success!", { status: 200 })
+
+    window.fetch = jest.fn().mockResolvedValue(mockResponse)
+    window.Turbo = { fetch: jest.fn().mockResolvedValue(mockResponse) }
+
+    const testRequest = new FetchRequest("get", "localhost")
+    const testResponse = await testRequest.perform()
+
+    expect(window.Turbo.fetch).toHaveBeenCalledTimes(0)
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+    expect(testResponse).toStrictEqual(new FetchResponse(mockResponse))
+  })
+})

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -19,7 +19,10 @@ export class FetchRequest {
       console.error(error)
     }
 
-    const response = new FetchResponse(await window.fetch(this.url, this.fetchOptions))
+    const fetch = (this.responseKind === 'turbo-stream' && window.Turbo)
+      ? window.Turbo.fetch : window.fetch
+
+    const response = new FetchResponse(await fetch(this.url, this.fetchOptions))
 
     if (response.unauthenticated && response.authenticationURL) {
       return Promise.reject(window.location.href = response.authenticationURL)

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -20,7 +20,8 @@ export class FetchRequest {
     }
 
     const fetch = (this.responseKind === 'turbo-stream' && window.Turbo)
-      ? window.Turbo.fetch : window.fetch
+      ? window.Turbo.fetch
+      : window.fetch
 
     const response = new FetchResponse(await fetch(this.url, this.fetchOptions))
 


### PR DESCRIPTION
Checks for `window.Turbo` and if the `responseKind` is `turbo-stream` and if both are true then `request.js` will use `window.Turbo.fetch` in order to append `X-Turbo-Request-Id` to the request headers.

The tests don't actually bring in Turbo just as the existing tests don't.

`window.Turbo.fetch` as at time of writing:
https://github.com/hotwired/turbo/blob/4d65288e913d5a5428e290781313c7909763b133/src/http/fetch.js

Closes: https://github.com/rails/request.js/issues/73