### PR TITLE
Consider https for same origin check

### DIFF
--- a/__tests__/fetch_request.js
+++ b/__tests__/fetch_request.js
@@ -223,8 +223,13 @@ describe('header handling', () => {
 
   describe('csrf token inclusion', () => {
     // window.location.hostname is "localhost" in the test suite
-    test('csrf token is not included in headers if url hostname is not the same as window.location', () => {
+    test('csrf token is not included in headers if url hostname is not the same as window.location (http)', () => {
       const request = new FetchRequest("get", "http://removeservice.com/test.json")
+      expect(request.fetchOptions.headers).not.toHaveProperty("X-CSRF-Token")
+    })
+
+    test('csrf token is not included in headers if url hostname is not the same as window.location (https)', () => {
+      const request = new FetchRequest("get", "https://removeservice.com/test.json")
       expect(request.fetchOptions.headers).not.toHaveProperty("X-CSRF-Token")
     })
 

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -49,7 +49,7 @@ export class FetchRequest {
   }
 
   sameHostname () {
-    if (!this.originalUrl.startsWith('http:')) {
+    if (!this.originalUrl.startsWith('http:') && !this.originalUrl.startsWith('https:')) {
       return true
     }
 


### PR DESCRIPTION
Closes #80

Adds an additional check in `sameHostname` to not include the CSRF token for https requests on different domains.