### PR TITLE
Add the ability to pass through the keepalive configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Specifies which response format will be accepted. Default is `html`.
 
 Options are `html`, `turbo-stream`, `json`, and `script`.
 
+##### keepalive
+
+Specifies the `keepalive` option. Default is `false`.
+
 #### Turbo Streams
 
 Request.JS will automatically process Turbo Stream responses. Ensure that your Javascript sets the `window.Turbo` global variable:

--- a/__tests__/fetch_request.js
+++ b/__tests__/fetch_request.js
@@ -221,6 +221,15 @@ describe('header handling', () => {
     expect(request.fetchOptions.credentials).toBe('include')
   })
 
+  test('has keepalive setting which can be changed', () => {
+    let request
+    request = new FetchRequest("get", "localhost")
+    expect(request.fetchOptions.keepalive).toBe(false)
+
+    request = new FetchRequest("get", "localhost", { keepalive: true})
+    expect(request.fetchOptions.keepalive).toBe(true)
+  })
+
   describe('csrf token inclusion', () => {
     // window.location.hostname is "localhost" in the test suite
     test('csrf token is not included in headers if url hostname is not the same as window.location (http)', () => {

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -67,7 +67,8 @@ export class FetchRequest {
       body: this.formattedBody,
       signal: this.signal,
       credentials: this.credentials,
-      redirect: this.redirect
+      redirect: this.redirect,
+      keepalive: this.keepalive
     }
   }
 
@@ -159,6 +160,10 @@ export class FetchRequest {
 
   get credentials () {
     return this.options.credentials || 'same-origin'
+  }
+
+  get keepalive () {
+    return this.options.keepalive || false
   }
 
   get additionalHeaders () {


### PR DESCRIPTION
I have a few concerns:

- We're hard coding the current defaults for `fetch` for many options. Why not just omit passing them if they're not passed in?
- It might be more future proof to allow any options to be passed in, and just override those specific options like `contentType` and `headers` as needed.

The solution to those is a much larger change, so for now just allowing `keepalive` through solves my immediate use-case.

Closes #85