### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
-      - uses: actions/cache@v2
+          node-version: '22'
+      - uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
The Github CI workflow is a bit out of date.

This is my attempt to get CI working again.

- Update the cache action to v4.
- Use the latest LTS of Node.