### PR TITLE
Allow passing through 'priority' param for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ async myMethod () {
 }
 ```
 
+#### Fetch Priority
+
+You can use the [`priority`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) option to hint the browser on the relative importance of a request
+
+```js
+import { get, post } from '@rails/request.js'
+
+// High priority fetch (e.g. critical data above the fold)
+const response = await get('/api/critical-data', { priority: 'high', responseKind: 'json' })
+
+// Low priority fetch (e.g. prefetch or analytics)
+await post('/api/analytics', { body: payload, priority: 'low' })
+```
+
 #### Request Options
 
 You can pass options to a request as the last argument. For example:
@@ -108,6 +122,10 @@ Options are `html`, `turbo-stream`, `json`, and `script`.
 ##### keepalive
 
 Specifies the `keepalive` option. Default is `false`.
+
+##### priority
+
+Specifies the [fetch priority](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) of the request relative to other requests of the same type. Must be one of `"high"`, `"low"`, or `"auto"` (default browser behavior when not specified).
 
 #### Turbo Streams
 

--- a/__tests__/fetch_request.js
+++ b/__tests__/fetch_request.js
@@ -230,6 +230,21 @@ describe('header handling', () => {
     expect(request.fetchOptions.keepalive).toBe(true)
   })
 
+  test('sets priority', () => {
+    let request
+    request = new FetchRequest("get", "localhost")
+    expect(request.fetchOptions.priority).toBe(undefined)
+
+    request = new FetchRequest("get", "localhost", { priority: "high" })
+    expect(request.fetchOptions.priority).toBe("high")
+
+    request = new FetchRequest("get", "localhost", { priority: "low" })
+    expect(request.fetchOptions.priority).toBe("low")
+
+    request = new FetchRequest("get", "localhost", { priority: "auto" })
+    expect(request.fetchOptions.priority).toBe("auto")
+  })
+
   describe('csrf token inclusion', () => {
     // window.location.hostname is "localhost" in the test suite
     test('csrf token is not included in headers if url hostname is not the same as window.location (http)', () => {

--- a/src/fetch_request.js
+++ b/src/fetch_request.js
@@ -65,7 +65,8 @@ export class FetchRequest {
       signal: this.signal,
       credentials: this.credentials,
       redirect: this.redirect,
-      keepalive: this.keepalive
+      keepalive: this.keepalive,
+      priority: this.priority
     }
   }
 
@@ -153,6 +154,10 @@ export class FetchRequest {
 
   get redirect () {
     return this.options.redirect || 'follow'
+  }
+
+  get priority () {
+    return this.options.priority
   }
 
   get credentials () {


### PR DESCRIPTION
It'd be nice to be able to pass in the `priority` param into the Fetch API when using this library.

Here's a PR to add support for that.